### PR TITLE
Add 'cover' target

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,6 @@ branch = True
 concurrency = multiprocessing
 parallel = True
 source =
-    buck/
+    buck
 omit =
     .tox/*

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
-    - name: Test with tox
+    - name: Test with tox (python ${{ matrix.python-version }})
       run: tox
   lint:
     runs-on: ubuntu-latest
@@ -37,5 +37,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
-    - name: Test with tox
+    - name: Check pep8
       run: tox -e pep8
+  cover:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python '3.10'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Check coverage
+      run: tox -e cover

--- a/buck/tools/cover.sh
+++ b/buck/tools/cover.sh
@@ -30,6 +30,12 @@ fi
 # Checkout master and save coverage report
 git checkout HEAD^
 
+# trap ctrl-c and call ctrl_c() which restores the branch.
+trap ctrl_c INT
+function ctrl_c() {
+        git checkout -
+}
+
 # base_op_count=`grep "op\." -R magnum/db/sqlalchemy/alembic/versions/ | wc -l`
 base_op_count=0
 baseline_report=$(mktemp -t buck_coverage-baseline-XXXXXXX)
@@ -44,6 +50,7 @@ coverage xml -o cover-master/coverage.xml
 
 # Checkout back and save coverage report
 git checkout -
+trap - INT  # no need to restore git branch from here onwards.
 
 # current_op_count=`grep "op\." -R magnum/db/sqlalchemy/alembic/versions/ | wc -l`
 current_op_count=0

--- a/buck/tools/cover.sh
+++ b/buck/tools/cover.sh
@@ -32,7 +32,7 @@ git checkout HEAD^
 
 # base_op_count=`grep "op\." -R magnum/db/sqlalchemy/alembic/versions/ | wc -l`
 base_op_count=0
-baseline_report=$(mktemp -t buck_coverageXXXXXXX)
+baseline_report=$(mktemp -t buck_coverage-baseline-XXXXXXX)
 coverage erase
 find . -type f -name "*.pyc" -delete
 stestr run --no-subunit-trace $*
@@ -47,7 +47,7 @@ git checkout -
 
 # current_op_count=`grep "op\." -R magnum/db/sqlalchemy/alembic/versions/ | wc -l`
 current_op_count=0
-current_report=$(mktemp -t buck_coverageXXXXXXX)
+current_report=$(mktemp -t buck_coverage-current-XXXXXXX)
 coverage erase
 find . -type f -name "*.pyc" -delete
 stestr run --no-subunit-trace $*

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ commands =
 [testenv:cover]
 usedevelop = True
 setenv =
-  VIRTUAL_ENV={envdir}
+    {[testenv]setenv}
+    PYTHON=coverage run
 deps = .
      -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
This target checks the coverage is not dropped when new patches are proposed for merging.

The 'cover.sh' tool assumes gerrit workflow where 1 patch is 1 pull request, this needs to be revisited to have accurate reports for github, although the usage of cover.sh over something more 'github native' like https://app.codecov.io/ is desired to catch early possible issues that may affect downstream consumers (e.g. the charms).